### PR TITLE
Add Category, FaqCategory and admin faq categories CRUD (#28)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,8 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'simple_form', '~> 5.0.2'
 gem 'slim', '~> 4.0.1'
 
-gem 'strong_migrations'
+gem 'mobility', '~> 0.8.13'
+gem 'strong_migrations', '~> 0.6.0'
 
 gem 'devise', '~> 4.7.1'
 gem 'mailgun-ruby', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,9 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
+    mobility (0.8.13)
+      i18n (>= 0.6.10, < 2)
+      request_store (~> 1.0)
     msgpack (1.3.3)
     msgpack (1.3.3-java)
     msgpack (1.3.3-x64-mingw32)
@@ -226,6 +229,8 @@ GEM
       ffi (~> 1.0)
     redis (4.2.1)
     regexp_parser (1.7.0)
+    request_store (1.5.0)
+      rack (>= 1.4)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -389,6 +394,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   mailgun-ruby (~> 1.2)
+  mobility (~> 0.8.13)
   pg (>= 0.18, < 2.0)
   puma (~> 4.3.5)
   rails (~> 6.0.3.1)
@@ -403,7 +409,7 @@ DEPENDENCIES
   slim (~> 4.0.1)
   spring
   spring-watcher-listen (~> 2.0.0)
-  strong_migrations
+  strong_migrations (~> 0.6.0)
   tzinfo-data
   web-console (>= 3.3.0)
   webpacker (~> 5.1.1)

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -5,7 +5,8 @@ module Admin
     before_action :find_account, except: :index
 
     def index
-      @accounts = current_scope.order(id: :desc)
+      @accounts = current_scope.where(region: current_region)
+                               .order(id: :desc)
     end
 
     def edit; end

--- a/app/controllers/admin/faq_categories_controller.rb
+++ b/app/controllers/admin/faq_categories_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Admin
+  class FaqCategoriesController < AdminController
+    before_action :find_faq_category, only: %i[edit update destroy]
+
+    def index
+      @categories = current_scope.includes(:string_translations)
+                                 .where(region: current_region)
+                                 .order(:position)
+    end
+
+    def new
+      @category = current_scope.new(region: current_region)
+    end
+
+    def create
+      @category = current_scope.new(faq_category_params)
+      return redirect_to_index if @category.save
+
+      flash_and_render(:new)
+    end
+
+    def edit; end
+
+    def update
+      return redirect_to_index if @category.update(faq_category_params)
+
+      flash_and_render(:edit)
+    end
+
+    def destroy
+      redirect_to_index if @category.destroy
+    end
+
+    private
+
+      def find_faq_category
+        @category = current_scope.find(params[:id])
+      end
+
+      def current_scope
+        @current_scope ||= FaqCategory
+      end
+
+      def faq_category_params
+        params.require(:faq_category)
+              .permit(
+                :name_en,
+                :name_zh_tw,
+                :region
+              )
+      end
+  end
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,6 +1,37 @@
 # frozen_string_literal: true
 
 class AdminController < ApplicationController
-  before_action :authenticate_admin_user!
   layout 'backend'
+
+  before_action :authenticate_admin_user!
+  helper_method :available_regions
+  helper_method :current_region
+
+  private
+
+    def redirect_to_index
+      paramaters = {}
+      paramaters[:action] = :index
+      paramaters[:region_id] = current_region
+
+      flash_success
+      redirect_to url_for(paramaters)
+    end
+
+    def flash_and_render(partial)
+      flash_fail
+      render partial
+    end
+
+    def flash_fail
+      flash.now[:alert] = t('controller.actions.fail')
+    end
+
+    def current_region
+      params[:region_id]
+    end
+
+    def available_regions
+      %w[domestic foreign]
+    end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   layout 'frontend'
+
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
@@ -12,26 +13,12 @@ class ApplicationController < ActionController::Base
       )
     end
 
-    def redirect_to_index
-      redirect_to url_for(action: :index)
-      flash_success
-    end
-
-    def flash_and_render(partial)
-      flash_fail
-      render partial
-    end
-
   private
 
     def flash_success
       flash[:notice] =
         t("controller.actions.#{action_name}_success",
           resource: current_scope.model_name.human)
-    end
-
-    def flash_fail
-      flash.now[:alert] = t('controller.actions.fail')
     end
 
     def current_scope

--- a/app/helpers/admin/components_helper.rb
+++ b/app/helpers/admin/components_helper.rb
@@ -3,8 +3,12 @@
 module Admin
   module ComponentsHelper
     def go_back_button
+      paramaters = {}
+      paramaters[:region_id] = params[:region_id]
+      paramaters[:action] = :index
+
       link_to t('utilities.buttons.back'),
-              url_for(action: :index),
+              url_for(paramaters),
               class: 'btn btn-block btn-outline-secondary'
     end
   end

--- a/app/helpers/admin/header_helper.rb
+++ b/app/helpers/admin/header_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Admin
+  module HeaderHelper
+    def page_header(resource)
+      action_for_resource =
+        t("backend.#{action_name}", resource: t("activerecord.models.#{resource}"))
+      return action_for_resource unless current_region
+
+      region = t("backend.available_regions.#{current_region}")
+      "#{action_for_resource} - #{region}"
+    end
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  name       :string           default(""), not null
+#  position   :integer          default(0), not null
+#  region     :integer          default("domestic"), not null
+#  type       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_categories_on_position  (position)
+#  index_categories_on_region    (region)
+#
+
+class Category < ApplicationRecord
+  enum region: { domestic: 0, foreign: 1 }
+
+  validates :name,     presence: true
+  validates :position, presence: true
+  validates :region,   presence: true
+  validates :type,     presence: true
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,6 +19,9 @@
 #
 
 class Category < ApplicationRecord
+  extend Mobility
+  translates :name, type: :string
+
   enum region: { domestic: 0, foreign: 1 }
 
   validates :name,     presence: true

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -24,8 +24,9 @@ class Category < ApplicationRecord
 
   enum region: { domestic: 0, foreign: 1 }
 
-  validates :name,     presence: true
-  validates :position, presence: true
-  validates :region,   presence: true
-  validates :type,     presence: true
+  validates :name_en,    presence: true
+  validates :name_zh_tw, presence: true
+  validates :position,   presence: true
+  validates :region,     presence: true
+  validates :type,       presence: true
 end

--- a/app/models/faq_category.rb
+++ b/app/models/faq_category.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  name       :string           default(""), not null
+#  position   :integer          default(0), not null
+#  region     :integer          default("domestic"), not null
+#  type       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_categories_on_position  (position)
+#  index_categories_on_region    (region)
+#
+
+class FaqCategory < Category; end

--- a/app/views/admin/accounts/edit.html.slim
+++ b/app/views/admin/accounts/edit.html.slim
@@ -3,7 +3,7 @@
     header.card-header
       = page_header('account')
     .card-body
-      = simple_form_for [:admin, @account], wrapper: :horizontal_form do |f|
+      = simple_form_for @account, url: admin_region_account_path, wrapper: :horizontal_form do |f|
         = f.input :status, as: :select, required: true,
                            collection: Account.statuses.keys.last(2).map { |k| [t("activerecord.attributes.account/status.#{k}"), k]}
 

--- a/app/views/admin/accounts/edit.html.slim
+++ b/app/views/admin/accounts/edit.html.slim
@@ -1,7 +1,7 @@
 .d-flex.justify-content-around
   section.card.col-12
     header.card-header
-      = t(action_name, resource: t('activerecord.models.account'))
+      = page_header('account')
     .card-body
       = simple_form_for [:admin, @account], wrapper: :horizontal_form do |f|
         = f.input :status, as: :select, required: true,

--- a/app/views/admin/accounts/index.html.slim
+++ b/app/views/admin/accounts/index.html.slim
@@ -1,7 +1,7 @@
 .d-flex.justify-content-around
   section.card.col-12.pb-3
     header.card-header.mb-3
-      = t('index', resource: t('activerecord.models.account'))
+      = page_header('account')
     .d-flex.px-2.pb-2.mt-3.justify-content-between.font-weight-bold
       .col-1.text-center = t('activerecord.attributes.account.status')
       .col-3 = t('activerecord.attributes.account.company_name')

--- a/app/views/admin/accounts/index.html.slim
+++ b/app/views/admin/accounts/index.html.slim
@@ -20,6 +20,6 @@
           .col-2.align-self-center
             = l(account.created_at.to_date, format: :default)
           .col-2.text-right.p-0.align-self-center
-            = link_to edit_admin_account_path(account),
+            = link_to edit_admin_region_account_path(id: account),
                       class: 'btn btn-primary btn-sm' do
               i.fa.fa-pencil

--- a/app/views/admin/admin_users/edit.html.slim
+++ b/app/views/admin/admin_users/edit.html.slim
@@ -1,7 +1,7 @@
 .d-flex.justify-content-around
   section.card.col-12
     header.card-header
-      = t(action_name, resource: t('activerecord.models.admin_user'))
+      = page_header('admin_user')
     .card-body
       = simple_form_for(@admin_user, url: admin_user_path, wrapper: :horizontal_form) do |f|
         = f.input :email, pattern: true

--- a/app/views/admin/faq_categories/_form.html.slim
+++ b/app/views/admin/faq_categories/_form.html.slim
@@ -1,0 +1,14 @@
+.d-flex.justify-content-around
+  section.card.col-12
+    header.card-header
+      = page_header('faq_category')
+    .card-body
+      = simple_form_for category, url: url, wrapper: :horizontal_form do |f|
+        = f.input :region, value: current_region, as: :hidden
+        = f.input :name_zh_tw
+        = f.input :name_en
+
+        .form-group.mt-5
+          = f.button :submit, class: 'btn btn-block btn-primary'
+        .form-group
+          = go_back_button

--- a/app/views/admin/faq_categories/edit.html.slim
+++ b/app/views/admin/faq_categories/edit.html.slim
@@ -1,0 +1,2 @@
+= render 'form', category: @category,
+                 url: admin_region_faq_category_path

--- a/app/views/admin/faq_categories/index.html.slim
+++ b/app/views/admin/faq_categories/index.html.slim
@@ -1,0 +1,26 @@
+.d-flex.justify-content-around
+  section.card.col-12.pb-3
+    header.card-header.mb-3
+      = page_header('faq_category')
+      .m-3.text-right
+        = link_to new_admin_region_faq_category_path, class: 'text-success'
+          i.fa.fa-plus.fa-2x
+    .d-flex.px-2.pb-2.font-weight-bold
+      .col-1
+      .col-9 = t('activerecord.attributes.faq_category.name')
+      .col-2
+    ul.list-group
+      - @categories.each do |category|
+        li.list-group-item.px-2.d-flex.justify-content-between
+          i.col-1.fa.fa-bars.align-self-center.text-center
+          span.col-9.align-self-center
+            = category.name
+          span.col-2.text-right
+            = link_to edit_admin_region_faq_category_path(id: category),
+                      class: 'btn btn-primary btn-sm' do
+              i.fa.fa-pencil
+            = link_to admin_region_faq_category_path(id: category),
+                      method: :delete,
+                      data: { confirm: t('utilities.alerts.delete_confirmation') },
+                      class: 'btn btn-danger btn-sm ml-2' do
+              i.fa.fa-trash

--- a/app/views/admin/faq_categories/new.html.slim
+++ b/app/views/admin/faq_categories/new.html.slim
@@ -1,0 +1,2 @@
+= render 'form', category: @category,
+                 url: admin_region_faq_categories_path

--- a/app/views/backend/_sidebar.html.slim
+++ b/app/views/backend/_sidebar.html.slim
@@ -1,10 +1,15 @@
 aside
   #sidebar.nav-collapse
     ul#nav-accordion.sidebar-menu
-      li
-        = link_to admin_accounts_path, class: (sidebar_active_on('account')) do
+      li.sub-menu
+        a[href="#"]
           i.fa.fa-users
-          span = "#{t('activerecord.models.account')}/#{t('activerecord.models.user')}"
+          span = t('activerecord.models.account')
+        ul.sub
+          - available_regions.each do |region|
+            li
+              = link_to t("backend.available_regions.#{region}"),
+                        admin_region_accounts_path(region_id: region)
       li.sub-menu
         a[href="#"]
           i.fa.fa-question-circle
@@ -12,4 +17,5 @@ aside
         ul.sub
           - available_regions.each do |region|
             li
-              = link_to t("activerecord.attributes.faq_category/region.#{region}"), admin_region_faq_categories_path(region_id: region)
+              = link_to t("backend.available_regions.#{region}"),
+                        admin_region_faq_categories_path(region_id: region)

--- a/app/views/backend/_sidebar.html.slim
+++ b/app/views/backend/_sidebar.html.slim
@@ -5,15 +5,11 @@ aside
         = link_to admin_accounts_path, class: (sidebar_active_on('account')) do
           i.fa.fa-users
           span = "#{t('activerecord.models.account')}/#{t('activerecord.models.user')}"
-      / li.sub-menu
-      /   a[href="#"]
-      /     i.fa.fa-laptop
-      /     span
-      /       | Page
-      /   ul.sub
-      /     li
-      /       a[href="#"]
-      /         | Sub page
-      /     li
-      /       a[href="#"]
-      /         | Sub page
+      li.sub-menu
+        a[href="#"]
+          i.fa.fa-question-circle
+          span = t('activerecord.models.faq_category')
+        ul.sub
+          - available_regions.each do |region|
+            li
+              = link_to t("activerecord.attributes.faq_category/region.#{region}"), admin_region_faq_categories_path(region_id: region)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
 require "rails"
@@ -31,8 +33,5 @@ module Rails6Base
 
     # Don't generate system test files.
     config.generators.system_tests = nil
-
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml')]
-    config.i18n.default_locale = :'zh-TW'
   end
 end

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml')]
+I18n.default_locale = :'zh-TW'
+I18n.available_locales = %i[en zh-TW]

--- a/config/initializers/mobility.rb
+++ b/config/initializers/mobility.rb
@@ -1,0 +1,90 @@
+Mobility.configure do |config|
+  # Sets the default backend to use in models. This can be overridden in models
+  # by passing +backend: ...+ to +translates+.
+  config.default_backend = :key_value
+
+  # By default, Mobility uses the +translates+ class method in models to
+  # describe translated attributes, but you can configure this method to be
+  # whatever you like. This may be useful if using Mobility alongside another
+  # translation gem which uses the same method name.
+  config.accessor_method = :translates
+
+  # To query on translated attributes, you need to append a scope to your
+  # model. The name of this scope is +i18n+ by default, but this can be changed
+  # to something else.
+  config.query_method    = :i18n
+
+  # Uncomment and remove (or add) items to (from) this list to completely
+  # disable/enable plugins globally (so they cannot be used and are never even
+  # loaded). Note that if you remove an item from the list, you will not be
+  # able to use the plugin at all, and any options for the plugin will be
+  # ignored by models. (In most cases, you probably don't want to change this.)
+  #
+  # config.plugins = %i[
+  #   query
+  #   cache
+  #   dirty
+  #   fallbacks
+  #   presence
+  #   default
+  #   attribute_methods
+  #   fallthrough_accessors
+  #   locale_accessors
+  # ]
+
+  # The translation cache is on by default, but you can turn it off by
+  # uncommenting this line. (This may be helpful in debugging.)
+  #
+  # config.default_options[:cache] = false
+
+  # Dirty tracking is disabled by default. Uncomment this line to enable it.
+  # If you enable this, you should also enable +locale_accessors+ by default
+  # (see below).
+  #
+  # config.default_options[:dirty] = true
+
+  # No fallbacks are used by default. To define default fallbacks, uncomment
+  # and set the default fallback option value here. A "true" value will use
+  # whatever is defined by +I18n.fallbacks+ (if defined), or alternatively will
+  # fallback to your +I18n.default_locale+.
+  #
+  # config.default_options[:fallbacks] = true
+
+  # The Presence plugin converts empty strings to nil when fetching and setting
+  # translations. By default it is on, uncomment this line to turn it off.
+  #
+  # config.default_options[:presence] = false
+
+  # Set a default value to use if the translation is nil. By default this is
+  # off, uncomment and set a default to use it across all models (you probably
+  # don't want to do that).
+  #
+  # config.default_options[:default] = ...
+
+  # Uncomment to enable locale_accessors by default on models. A true value
+  # will use the locales defined either in
+  # Rails.application.config.i18n.available_locales or I18n.available_locales.
+  # If you want something else, pass an array of locales instead.
+  #
+  config.default_options[:locale_accessors] = true
+
+  # Uncomment to enable fallthrough accessors by default on models. This will
+  # allow you to call any method with a suffix like _en or _pt_br, and Mobility
+  # will catch the suffix and convert it into a locale in +method_missing+. If
+  # you don't need this kind of open-ended fallthrough behavior, it's better
+  # to use locale_accessors instead (which define methods) since method_missing
+  # is very slow. (You can use both fallthrough and locale accessor plugins
+  # together without conflict.)
+  #
+  # Note: The dirty plugin enables fallthrough_accessors by default.
+  #
+  # config.default_options[:fallthrough_accessors] = true
+
+  # You can also include backend-specific default options. For example, if you
+  # want to default to using the text-type translation table with the KeyValue
+  # backend, you can set that as a default by uncommenting this line, or change
+  # it to :string to default to the string-type translation table instead. (For
+  # other backends, this option is ignored.)
+  #
+  # config.default_options[:type] = :text
+end

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -5,6 +5,7 @@ en:
     models:
       account: Account
       admin_user: Admin User
+      faq_category: FAQ Category
       user: User
     attributes:
       account:
@@ -26,6 +27,12 @@ en:
       admin_user:
         password: Password
         password_confirmation: Password Confirmation
+      faq_category:
+        name: Name
+        region: Region
+      faq_category/region:
+        domestic: Taiwan
+        foreign: Foreign
       user:
         current_password: Current Password
         email: Email

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -29,7 +29,6 @@ en:
         password_confirmation: Password Confirmation
       faq_category:
         name: Name
-        region: Region
       faq_category/region:
         domestic: Taiwan
         foreign: Foreign

--- a/config/locales/models/zh-TW.yml
+++ b/config/locales/models/zh-TW.yml
@@ -29,7 +29,6 @@ zh-TW:
         password_confirmation: 確認密碼
       faq_category:
         name: 名稱
-        region: 地區
       faq_category/region:
         domestic: 台灣
         foreign: 海外

--- a/config/locales/models/zh-TW.yml
+++ b/config/locales/models/zh-TW.yml
@@ -5,6 +5,7 @@ zh-TW:
     models:
       account: 帳戶
       admin_user: 後台管理者
+      faq_category: FAQ 分類
       user: 使用者
     attributes:
       account:
@@ -26,6 +27,12 @@ zh-TW:
       admin_user:
         password: 密碼
         password_confirmation: 確認密碼
+      faq_category:
+        name: 名稱
+        region: 地區
+      faq_category/region:
+        domestic: 台灣
+        foreign: 海外
       user:
         current_password: 目前密碼
         email: 信箱

--- a/config/locales/simple_form/en.yml
+++ b/config/locales/simple_form/en.yml
@@ -8,6 +8,9 @@ en:
     error_notification:
       default_message: 'Please review the problems below:'
     labels:
+      faq_category:
+          name_en: Name - EN
+          name_zh_tw: Name - ZH
       user:
         edit:
           email: Email

--- a/config/locales/simple_form/zh-TW.yml
+++ b/config/locales/simple_form/zh-TW.yml
@@ -8,6 +8,9 @@ zh-TW:
     error_notification:
       default_message: 請檢視下方錯誤訊息：
     labels:
+      faq_category:
+        name_en: 名稱 - 英文
+        name_zh_tw: 名稱 - 中文
       user:
         edit:
           email: 信箱

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1,8 +1,4 @@
 en:
-  new: "New %{resource}"
-  edit: "Edit %{resource}"
-  index: "%{resource} List"
-  update: "Edit %{resource}"
   accounts:
     registrations:
       new:
@@ -28,6 +24,15 @@ en:
       edit:
         account_info: Account Info
         user_info: User Info
+  backend:
+    available_regions:
+      domestic: Taiwan
+      foreign: Foerign
+    create: "Create %{resource}"
+    edit: "Edit %{resource}"
+    index: "%{resource} List"
+    new: "New %{resource}"
+    update: "Edit %{resource}"
   frontend:
     header:
       links:

--- a/config/locales/views/zh-TW.yml
+++ b/config/locales/views/zh-TW.yml
@@ -1,8 +1,4 @@
 zh-TW:
-  new: "新增 %{resource}"
-  edit: "編輯 %{resource}"
-  index: "%{resource}列表"
-  update: "編輯 %{resource}"
   accounts:
     registrations:
       new:
@@ -28,6 +24,15 @@ zh-TW:
       edit:
         account_info: 帳戶資訊
         user_info: 使用者資訊
+  backend:
+    available_regions:
+      domestic: 台灣
+      foreign: 海外
+    create: "新增 %{resource}"
+    edit: "編輯 %{resource}"
+    index: "%{resource}列表"
+    new: "新增 %{resource}"
+    update: "編輯 %{resource}"
   frontend:
     header:
       links:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,9 +29,9 @@ Rails.application.routes.draw do
 
     resource :admin_users, only: %i[edit update], as: :user
 
-    resources :accounts, only: %i[index edit update]
 
     resources :regions, path: '', only: [] do
+      resources :accounts, only: %i[index edit update]
       resources :faq_categories, except: :show
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,5 +30,9 @@ Rails.application.routes.draw do
     resource :admin_users, only: %i[edit update], as: :user
 
     resources :accounts, only: %i[index edit update]
+
+    resources :regions, path: '', only: [] do
+      resources :faq_categories, except: :show
+    end
   end
 end

--- a/db/migrate/20200730155938_create_categories.rb
+++ b/db/migrate/20200730155938_create_categories.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateCategories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :categories do |t|
+      t.string :type, null: false
+      t.string :name, null: false, default: ''
+      t.integer :region, null: false, default: 0
+      t.integer :position, null: false, default: 0
+
+      t.timestamps
+    end
+    add_index :categories, :region
+    add_index :categories, :position
+  end
+end

--- a/db/migrate/20200730163011_create_text_translations.rb
+++ b/db/migrate/20200730163011_create_text_translations.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateTextTranslations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :mobility_text_translations do |t|
+      t.string :locale, null: false
+      t.string :key,    null: false
+      t.text :value
+      t.references :translatable, polymorphic: true, index: false
+      t.timestamps null: false
+    end
+    add_index :mobility_text_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
+    add_index :mobility_text_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
+  end
+end

--- a/db/migrate/20200730163012_create_string_translations.rb
+++ b/db/migrate/20200730163012_create_string_translations.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateStringTranslations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :mobility_string_translations do |t|
+      t.string :locale, null: false
+      t.string :key, null: false
+      t.string :value
+      t.references :translatable, polymorphic: true, index: false
+      t.timestamps null: false
+    end
+
+    safety_assured do
+      add_index :mobility_string_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys
+      add_index :mobility_string_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_string_translations_on_translatable_attribute
+      add_index :mobility_string_translations, [:translatable_type, :key, :value, :locale], name: :index_mobility_string_translations_on_query_keys
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_30_155938) do
+ActiveRecord::Schema.define(version: 2020_07_30_163012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,31 @@ ActiveRecord::Schema.define(version: 2020_07_30_155938) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["position"], name: "index_categories_on_position"
     t.index ["region"], name: "index_categories_on_region"
+  end
+
+  create_table "mobility_string_translations", force: :cascade do |t|
+    t.string "locale", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.string "translatable_type"
+    t.bigint "translatable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["translatable_id", "translatable_type", "key"], name: "index_mobility_string_translations_on_translatable_attribute"
+    t.index ["translatable_id", "translatable_type", "locale", "key"], name: "index_mobility_string_translations_on_keys", unique: true
+    t.index ["translatable_type", "key", "value", "locale"], name: "index_mobility_string_translations_on_query_keys"
+  end
+
+  create_table "mobility_text_translations", force: :cascade do |t|
+    t.string "locale", null: false
+    t.string "key", null: false
+    t.text "value"
+    t.string "translatable_type"
+    t.bigint "translatable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["translatable_id", "translatable_type", "key"], name: "index_mobility_text_translations_on_translatable_attribute"
+    t.index ["translatable_id", "translatable_type", "locale", "key"], name: "index_mobility_text_translations_on_keys", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_18_163544) do
+ActiveRecord::Schema.define(version: 2020_07_30_155938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,17 @@ ActiveRecord::Schema.define(version: 2020_07_18_163544) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "type", null: false
+    t.string "name", default: "", null: false
+    t.integer "region", default: 0, null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["position"], name: "index_categories_on_position"
+    t.index ["region"], name: "index_categories_on_region"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  name       :string           default(""), not null
+#  position   :integer          default(0), not null
+#  region     :integer          default("domestic"), not null
+#  type       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_categories_on_position  (position)
+#  index_categories_on_region    (region)
+#
+
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:position) }
+    it { should validate_presence_of(:region) }
+    it { should validate_presence_of(:type) }
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -22,7 +22,8 @@ require 'rails_helper'
 
 RSpec.describe Category, type: :model do
   describe 'validations' do
-    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:name_en) }
+    it { should validate_presence_of(:name_zh_tw) }
     it { should validate_presence_of(:position) }
     it { should validate_presence_of(:region) }
     it { should validate_presence_of(:type) }


### PR DESCRIPTION
## Table Added
- Add `categories` table (#28) (#29)

## Dependency Added
- Add `Mobility 0.8.13` (#28) (#29)

## Added
- Add `Category` and `FaqCategory` with validations and specs (#28) (#29)
- Initialize Mobility (#28) (#29)
  - Add config/initializers/mobilit y.rb
  - Add text_translations table
  - Add string_translations table
- Extend Mobility in Category (#28) (#29)
- Add admin faq_categories CRUD (#28) (#29)
- Add Admin::HeaderHelper#page_header for admin pages (#29)

## Changed
- Move I18n config to config/initializers/locale.rb (#29)
- Move admin accounts under regions resources (#29)