### PR TITLE
Add sortable to admin faq_categories (#30)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'simple_form', '~> 5.0.2'
 gem 'slim', '~> 4.0.1'
 
+gem 'acts_as_list', '~> 1.0.1'
 gem 'mobility', '~> 0.8.13'
 gem 'strong_migrations', '~> 0.6.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    acts_as_list (1.0.1)
+      activerecord (>= 4.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
@@ -376,6 +378,7 @@ PLATFORMS
   x86-mswin32
 
 DEPENDENCIES
+  acts_as_list (~> 1.0.1)
   annotate (~> 3.0.3)
   bootsnap (>= 1.4.2)
   bullet (~> 6.1)

--- a/app/controllers/admin/faq_categories_controller.rb
+++ b/app/controllers/admin/faq_categories_controller.rb
@@ -43,6 +43,10 @@ module Admin
         @current_scope ||= FaqCategory
       end
 
+      def current_sort_path
+        sort_admin_region_faq_categories_path
+      end
+
       def faq_category_params
         params.require(:faq_category)
               .permit(

--- a/app/controllers/admin/faq_categories_controller.rb
+++ b/app/controllers/admin/faq_categories_controller.rb
@@ -2,6 +2,8 @@
 
 module Admin
   class FaqCategoriesController < AdminController
+    include Admin::Sortable
+
     before_action :find_faq_category, only: %i[edit update destroy]
 
     def index

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -27,11 +27,15 @@ class AdminController < ApplicationController
       flash.now[:alert] = t('controller.actions.fail')
     end
 
+    def available_regions
+      %w[domestic foreign]
+    end
+
     def current_region
       params[:region_id]
     end
 
-    def available_regions
-      %w[domestic foreign]
+    def current_sort_path
+      raise NotImplementedError
     end
 end

--- a/app/controllers/concerns/admin/sortable.rb
+++ b/app/controllers/concerns/admin/sortable.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Admin
+  module Sortable
+    extend ActiveSupport::Concern
+
+    included do
+      helper_method :sort_path
+
+      def sort
+        sort_item = JSON.parse(params[:sort])
+                        .transform_keys(&:to_sym)
+
+        current_scope.find(sort_item[:id])
+                     .insert_at(sort_item[:position].to_i)
+
+        head :ok
+      end
+
+      def sort_path
+        current_sort_path
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/backend/simple_sort_controller.js
+++ b/app/javascript/controllers/backend/simple_sort_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from 'stimulus'
+import Rails from '@rails/ujs'
+import Sortable from 'sortablejs'
+
+export default class extends Controller {
+  connect() {
+    Sortable.create(this.element, {
+      onEnd: this.sort.bind(this)
+    })
+  }
+
+  sort(event) {
+    const formData = new FormData()
+    const sortData = {
+      id: event.item.dataset.id,
+      position: event.newIndex + 1
+    }
+
+    formData.append('sort', JSON.stringify(sortData))
+
+    Rails.ajax({
+      type: 'PATCH',
+      url: this.data.get('url'),
+      data: formData
+    })
+  }
+}

--- a/app/javascript/packs/backend.js
+++ b/app/javascript/packs/backend.js
@@ -3,13 +3,13 @@ import 'regenerator-runtime/runtime'
 require('@rails/ujs').start()
 
 import { Application } from 'stimulus'
-// import { definitionsFromContext } from 'stimulus/webpack-helpers'
+import { definitionsFromContext } from 'stimulus/webpack-helpers'
 import NotificationController from '../controllers/shared/notification_controller'
 
 const stimulus = Application.start()
+const controllers = require.context('../controllers/backend/', true, /\.js$/)
+stimulus.load(definitionsFromContext(controllers))
 stimulus.register('notification', NotificationController)
-// const controllers = require.context('../controllers/backend/', true, /.js$/)
-// stimulus.load(definitionsFromContext(controllers))
 
 import 'jquery'
 import '../src/backend/javascripts/'

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -22,6 +22,8 @@ class Category < ApplicationRecord
   extend Mobility
   translates :name, type: :string
 
+  acts_as_list scope: %i[type region]
+
   enum region: { domestic: 0, foreign: 1 }
 
   validates :name_en,    presence: true

--- a/app/views/admin/faq_categories/index.html.slim
+++ b/app/views/admin/faq_categories/index.html.slim
@@ -1,17 +1,17 @@
 .d-flex.justify-content-around
   section.card.col-12.pb-3
-    header.card-header.mb-3
+    header.card-header.border-0
       = page_header('faq_category')
       .m-3.text-right
         = link_to new_admin_region_faq_category_path, class: 'text-success'
           i.fa.fa-plus.fa-2x
-    .d-flex.px-2.pb-2.font-weight-bold
+    .d-flex.px-2.font-weight-bold
       .col-1
       .col-9 = t('activerecord.attributes.faq_category.name')
       .col-2
-    ul.list-group
+    ul.list-group data-controller = 'simple-sort' data-simple-sort-url = sort_path
       - @categories.each do |category|
-        li.list-group-item.px-2.d-flex.justify-content-between
+        li.list-group-item.px-2.mt-2.d-flex.justify-content-between.border.rounded data-id = category.id
           i.col-1.fa.fa-bars.align-self-center.text-center
           span.col-9.align-self-center
             = category.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,9 @@ Rails.application.routes.draw do
 
     resources :regions, path: '', only: [] do
       resources :accounts, only: %i[index edit update]
-      resources :faq_categories, except: :show
+      resources :faq_categories, except: :show do
+        collection { patch :sort }
+      end
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "jquery": "^3.5.1",
     "popper.js": "^1.16.0",
     "regenerator-runtime": "^0.13.5",
+    "sortablejs": "^1.10.2",
     "stimulus": "^1.1.1",
     "url-polyfill": "^1.1.8",
     "webpack": "^4.42.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7094,6 +7094,11 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sortablejs@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.10.2.tgz#6e40364d913f98b85a14f6678f92b5c1221f5290"
+  integrity sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"


### PR DESCRIPTION
## Dependencies Added
- Add `acts_as_list 1.0.1` (#30) (#31)
- Add `sortablejs 1.10.2` (#30) (#31)

## Added
- Add `simple_sort_controller.js` (#30) (#31)
- Add `Admin::Sortable` controller concern (#30) (#31)
- Add sortable to admin faq_categories (#30) (#31)